### PR TITLE
devenv: use direct filesystem access for local paths outside of git repos

### DIFF
--- a/devenv-patches/0022-devenv-use-direct-filesystem-access-for-local-paths.patch
+++ b/devenv-patches/0022-devenv-use-direct-filesystem-access-for-local-paths.patch
@@ -1,0 +1,85 @@
+From 945d9df1694216597e4b5f3495e5db335f0718a7 Mon Sep 17 00:00:00 2001
+From: Sander <hey@sandydoo.me>
+Date: Mon, 7 Jul 2025 23:46:40 +0200
+Subject: [PATCH] devenv: use direct filesystem access for local paths outside
+ git repos
+
+Restore the ability to access local directories directly without copying
+to the Nix store, fixing getPhysicalPath() to return actual filesystem
+paths instead of store paths for non-git local directories.
+---
+ src/libfetchers/path.cc | 42 +++++++++++++++++++----------------------
+ 1 file changed, 19 insertions(+), 23 deletions(-)
+
+diff --git a/src/libfetchers/path.cc b/src/libfetchers/path.cc
+index 5906271b7..54ec37762 100644
+--- a/src/libfetchers/path.cc
++++ b/src/libfetchers/path.cc
+@@ -5,6 +5,7 @@
+ #include "nix/fetchers/cache.hh"
+ #include "nix/fetchers/fetch-to-store.hh"
+ #include "nix/fetchers/fetch-settings.hh"
++#include "nix/util/posix-source-accessor.hh"
+ 
+ namespace nix::fetchers {
+ 
+@@ -128,38 +129,33 @@ struct PathInputScheme : InputScheme
+ 
+         auto absPath = getAbsPath(input);
+ 
+-        Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", absPath));
+-
+         // FIXME: check whether access to 'path' is allowed.
+         auto storePath = store->maybeParseStorePath(absPath.string());
+ 
+-        if (storePath)
++        if (storePath) {
+             store->addTempRoot(*storePath);
+ 
+-        time_t mtime = 0;
+-        if (!storePath || storePath->name() != "source" || !store->isValidPath(*storePath)) {
+-            // FIXME: try to substitute storePath.
+-            auto src = sinkToSource([&](Sink & sink) {
+-                mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter);
+-            });
+-            storePath = store->addToStoreFromDump(*src, "source");
+-        }
++            // If it's already a store path, use store accessor
++            Activity act(*logger, lvlTalkative, actUnknown, fmt("using store path %s", absPath));
+ 
+-        auto accessor = makeStorePathAccessor(store, *storePath);
++            auto accessor = makeStorePathAccessor(store, *storePath);
+ 
+-        // To prevent `fetchToStore()` copying the path again to Nix
+-        // store, pre-create an entry in the fetcher cache.
+-        auto info = store->queryPathInfo(*storePath);
+-        accessor->fingerprint = fmt("path:%s", store->queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
+-        input.settings->getCache()->upsert(
+-            makeSourcePathToHashCacheKey(*accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, "/"),
+-            {{"hash", info->narHash.to_string(HashFormat::SRI, true)}});
++            // To prevent `fetchToStore()` copying the path again to Nix
++            // store, pre-create an entry in the fetcher cache.
++            auto info = store->queryPathInfo(*storePath);
++            accessor->fingerprint = fmt("path:%s", store->queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
++            input.settings->getCache()->upsert(
++                makeSourcePathToHashCacheKey(*accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, "/"),
++                {{"hash", info->narHash.to_string(HashFormat::SRI, true)}});
++
++            return {accessor, std::move(input)};
++        }
+ 
+-        /* Trust the lastModified value supplied by the user, if
+-           any. It's not a "secure" attribute so we don't care. */
+-        if (!input.getLastModified())
+-            input.attrs.insert_or_assign("lastModified", uint64_t(mtime));
++        // For local directories, use direct filesystem access like devenv-2.24 behavior
++        Activity act(*logger, lvlTalkative, actUnknown, fmt("using local directory %s", absPath));
+ 
++        auto accessor = makeFSSourceAccessor(absPath);
++        accessor->setPathDisplay(absPath.string());
+         return {accessor, std::move(input)};
+     }
+ 
+-- 
+2.49.0
+

--- a/devenv-patches/0023-devenv-fix-relative-path-resolution-in-call-flake.patch
+++ b/devenv-patches/0023-devenv-fix-relative-path-resolution-in-call-flake.patch
@@ -1,0 +1,31 @@
+From e114a9318a6d90740a43821581a3415d8423a674 Mon Sep 17 00:00:00 2001
+From: Sander <hey@sandydoo.me>
+Date: Thu, 10 Jul 2025 00:42:01 +0200
+Subject: [PATCH 2/2] devenv: fix relative path resolution in call-flake
+
+Use the original source location instead of the store path when
+resolving relative paths. This restores devenv-2.24 behaviour.
+---
+ src/libfetchers/git.cc | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/libfetchers/git.cc b/src/libfetchers/git.cc
+index 9de249394..1de9f2149 100644
+--- a/src/libfetchers/git.cc
++++ b/src/libfetchers/git.cc
+@@ -822,6 +822,12 @@ struct GitInputScheme : InputScheme
+             ? getLastModified(*input.settings, repoInfo, repoPath, *repoInfo.workdirInfo.headRev)
+             : 0);
+ 
++        // For non-flake inputs (flake: false), preserve the local filesystem path
++        // instead of forcing it through the store. This restores devenv-2.24 behavior.
++        if (input.attrs.find("__final") != input.attrs.end()) {
++            input.attrs.insert_or_assign("outPath", repoPath.string());
++        }
++
+         return {accessor, std::move(input)};
+     }
+ 
+-- 
+2.49.0
+

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -822,6 +822,12 @@ struct GitInputScheme : InputScheme
             ? getLastModified(*input.settings, repoInfo, repoPath, *repoInfo.workdirInfo.headRev)
             : 0);
 
+        // For non-flake inputs (flake: false), preserve the local filesystem path
+        // instead of forcing it through the store. This restores devenv-2.24 behavior.
+        if (input.attrs.find("__final") != input.attrs.end()) {
+            input.attrs.insert_or_assign("outPath", repoPath.string());
+        }
+
         return {accessor, std::move(input)};
     }
 

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -5,6 +5,7 @@
 #include "nix/fetchers/cache.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/fetchers/fetch-settings.hh"
+#include "nix/util/posix-source-accessor.hh"
 
 namespace nix::fetchers {
 
@@ -128,38 +129,33 @@ struct PathInputScheme : InputScheme
 
         auto absPath = getAbsPath(input);
 
-        Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", absPath));
-
         // FIXME: check whether access to 'path' is allowed.
         auto storePath = store->maybeParseStorePath(absPath.string());
 
-        if (storePath)
+        if (storePath) {
             store->addTempRoot(*storePath);
 
-        time_t mtime = 0;
-        if (!storePath || storePath->name() != "source" || !store->isValidPath(*storePath)) {
-            // FIXME: try to substitute storePath.
-            auto src = sinkToSource([&](Sink & sink) {
-                mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter);
-            });
-            storePath = store->addToStoreFromDump(*src, "source");
+            // If it's already a store path, use store accessor
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("using store path %s", absPath));
+
+            auto accessor = makeStorePathAccessor(store, *storePath);
+
+            // To prevent `fetchToStore()` copying the path again to Nix
+            // store, pre-create an entry in the fetcher cache.
+            auto info = store->queryPathInfo(*storePath);
+            accessor->fingerprint = fmt("path:%s", store->queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
+            input.settings->getCache()->upsert(
+                makeSourcePathToHashCacheKey(*accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, "/"),
+                {{"hash", info->narHash.to_string(HashFormat::SRI, true)}});
+
+            return {accessor, std::move(input)};
         }
 
-        auto accessor = makeStorePathAccessor(store, *storePath);
+        // For local directories, use direct filesystem access like devenv-2.24 behavior
+        Activity act(*logger, lvlTalkative, actUnknown, fmt("using local directory %s", absPath));
 
-        // To prevent `fetchToStore()` copying the path again to Nix
-        // store, pre-create an entry in the fetcher cache.
-        auto info = store->queryPathInfo(*storePath);
-        accessor->fingerprint = fmt("path:%s", store->queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true));
-        input.settings->getCache()->upsert(
-            makeSourcePathToHashCacheKey(*accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, "/"),
-            {{"hash", info->narHash.to_string(HashFormat::SRI, true)}});
-
-        /* Trust the lastModified value supplied by the user, if
-           any. It's not a "secure" attribute so we don't care. */
-        if (!input.getLastModified())
-            input.attrs.insert_or_assign("lastModified", uint64_t(mtime));
-
+        auto accessor = makeFSSourceAccessor(absPath);
+        accessor->setPathDisplay(absPath.string());
         return {accessor, std::move(input)};
     }
 


### PR DESCRIPTION
Restore the ability to access local directories directly without copying to the Nix store, fixing `getPhysicalPath()` to return actual filesystem paths instead of store paths for non-git local directories.
