### PR TITLE
path: fix NAR hash mismatch for unlocked local path inputs

### DIFF
--- a/devenv-patches/0024-always-allow-builtins-getenv-secretspec-secrets.patch
+++ b/devenv-patches/0024-always-allow-builtins-getenv-secretspec-secrets.patch
@@ -1,0 +1,32 @@
+From 54df04f09cb084b9e58529c0ae6f53f0e50f1a19 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Domen=20Ko=C5=BEar?= <domen@cachix.org>
+Date: Fri, 11 Jul 2025 11:34:59 -0500
+Subject: [PATCH 1/2] Always allow 'builtins.getEnv SECRETSPEC_SECRETS'.
+
+This way we avoid writing them to a file, but they still leak to drvs.
+---
+ src/libexpr/primops.cc | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/libexpr/primops.cc b/src/libexpr/primops.cc
+index 6b8b96d4c..faed8be70 100644
+--- a/src/libexpr/primops.cc
++++ b/src/libexpr/primops.cc
+@@ -1037,7 +1037,13 @@ static void prim_getEnv(EvalState & state, const PosIdx pos, Value * * args, Val
+ {
+     std::string name(state.forceStringNoCtx(*args[0], pos, "while evaluating the first argument passed to builtins.getEnv"));
+     printTalkative("devenv getEnv: '%1%'", name);
+-    v.mkString(state.settings.restrictEval || state.settings.pureEval ? "" : getEnv(name).value_or(""));
++
++    // Allow SECRETSPEC_SECRETS even in pure/restricted mode
++    if (name == "SECRETSPEC_SECRETS" || !(state.settings.restrictEval || state.settings.pureEval)) {
++        v.mkString(getEnv(name).value_or(""));
++    } else {
++        v.mkString("");
++    }
+ }
+ 
+ static RegisterPrimOp primop_getEnv({
+-- 
+2.49.0
+

--- a/devenv-patches/0025-path-fix-nar-hash-mismatch-for-unlocked-local-paths.patch
+++ b/devenv-patches/0025-path-fix-nar-hash-mismatch-for-unlocked-local-paths.patch
@@ -1,0 +1,55 @@
+From d879e0f029613a78ec5fe3667363de5fd3c97a58 Mon Sep 17 00:00:00 2001
+From: Sander <hey@sandydoo.me>
+Date: Sat, 12 Jul 2025 16:20:35 +0200
+Subject: [PATCH 2/2] path: fix NAR hash mismatch for unlocked local path
+ inputs
+
+Path inputs now support a `lock` attribute (defaults to false) that
+controls whether NAR hash computation and validation is performed.
+When `lock=false` (the default), path inputs use direct filesystem
+access without NAR hash validation, allowing source modifications
+without lock file regeneration.
+
+This restores the devenv-2.24 behavior where path inputs remained
+unlocked by default and reflected current filesystem state.
+---
+ src/libexpr/paths.cc    | 8 ++++++--
+ src/libfetchers/path.cc | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/libexpr/paths.cc b/src/libexpr/paths.cc
+index 770887564..6a07ca05e 100644
+--- a/src/libexpr/paths.cc
++++ b/src/libexpr/paths.cc
+@@ -90,10 +90,14 @@ StorePath EvalState::mountInput(
+ 
+     storeFS->mount(CanonPath(store->printStorePath(storePath)), accessor);
+ 
+-    if (requireLockable && (!settings.lazyTrees || !input.isLocked()) && !input.getNarHash())
++    // Check if this is a path input with lock=false - if so, don't force NAR hash computation and skip validation
++    bool isUnlockedPathInput = input.getType() == "path" &&
++                               fetchers::maybeGetBoolAttr(input.attrs, "lock").value_or(false) == false;
++
++    if (requireLockable && (!settings.lazyTrees || !input.isLocked()) && !input.getNarHash() && !isUnlockedPathInput)
+         input.attrs.insert_or_assign("narHash", getNarHash()->to_string(HashFormat::SRI, true));
+ 
+-    if (originalInput.getNarHash() && *getNarHash() != *originalInput.getNarHash())
++    if (originalInput.getNarHash() && !isUnlockedPathInput && *getNarHash() != *originalInput.getNarHash())
+         throw Error(
+             (unsigned int) 102,
+             "NAR hash mismatch in input '%s', expected '%s' but got '%s'",
+diff --git a/src/libfetchers/path.cc b/src/libfetchers/path.cc
+index 54ec37762..baa18e92b 100644
+--- a/src/libfetchers/path.cc
++++ b/src/libfetchers/path.cc
+@@ -48,6 +48,7 @@ struct PathInputScheme : InputScheme
+     {
+         return {
+             "path",
++            "lock",
+             /* Allow the user to pass in "fake" tree info
+                attributes. This is useful for making a pinned tree work
+                the same as the repository from which is exported (e.g.
+-- 
+2.49.0
+

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -48,6 +48,7 @@ struct PathInputScheme : InputScheme
     {
         return {
             "path",
+            "lock",
             /* Allow the user to pass in "fake" tree info
                attributes. This is useful for making a pinned tree work
                the same as the repository from which is exported (e.g.


### PR DESCRIPTION
Path inputs now support a `lock` attribute (defaults to false) that controls whether NAR hash computation and validation is performed.
When `lock=false` (the default), path inputs use direct filesystem access without NAR hash validation, allowing source modifications without lock file regeneration.

This restores the devenv-2.24 behavior where path inputs remained unlocked by default and reflected current filesystem state.